### PR TITLE
Add ConductR specifics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ project/plugins/project/
 .worksheet
 .classpath
 .project
+
+# IDEA specific
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import ByteConversions._
+
 organization in ThisBuild := "sample.chirper"
 
 // the Scala version that will be used for cross-compiled libraries
@@ -67,9 +69,16 @@ lazy val frontEnd = project("front-end")
       "org.webjars" % "react" % "0.14.3",
       "org.webjars" % "react-router" % "1.0.3",
       "org.webjars" % "jquery" % "2.2.0",
-      "org.webjars" % "foundation" % "5.3.0"
+      "org.webjars" % "foundation" % "5.3.0",
+      "com.typesafe.conductr" %% "lagom10-conductr-bundle-lib" % "1.4.1"
     ),
-    ReactJsKeys.sourceMapInline := true
+    ReactJsKeys.sourceMapInline := true,
+    // ConductR settings
+    BundleKeys.nrOfCpus := 1.0,
+    BundleKeys.memory := 64.MiB,
+    BundleKeys.diskSpace := 35.MB,
+    BundleKeys.endpoints := Map("web" -> Endpoint("http", services = Set(URI("http://:9000")))),
+    javaOptions in Bundle ++= Seq("-Dhttp.address=$WEB_BIND_IP", "-Dhttp.port=$WEB_BIND_PORT")
   )
 
 lazy val loadTestApi = project("load-test-api")

--- a/front-end/bundle-configuration/default/runtime-config.sh
+++ b/front-end/bundle-configuration/default/runtime-config.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export APPLICATION_SECRET=PPjOW0n2aV?s@6RdiNV@7/5xJhiiKTzk[VdHjkU9YHit8sLHoJ1rp0DCCn6b=lXt

--- a/front-end/conf/application.conf
+++ b/front-end/conf/application.conf
@@ -1,4 +1,5 @@
 play.crypto.secret = "changeme"
+play.crypto.secret = ${?APPLICATION_SECRET}
 
 lagom.play {
   service-name = "chirper-front-end"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-lagom-bundle" % "1.0.2")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.2")


### PR DESCRIPTION
Uses `lagom10-conductr-bundle-lib` version 1.4.1 that contains the fix: https://github.com/typesafehub/conductr-lib/pull/95
