### PR TITLE
Bump sbt-lagom-bundle to 1.0.3

### DIFF
--- a/front-end/bundle-configuration/default/runtime-config.sh
+++ b/front-end/bundle-configuration/default/runtime-config.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/env bash
+
+# This shell script is part of the bundle configuration of the `front-end` bundle.
+# When loading the `front-end` bundle with a bundle configuration on to ConductR then
+# this shell script is executed at the time the `front-end` bundle gets started.
+# In this simple script we set the `APPLICATION_SECRET` environment variable
+# to override the `play.crypto.secret` key of the `conf/application.conf`
 export APPLICATION_SECRET=PPjOW0n2aV?s@6RdiNV@7/5xJhiiKTzk[VdHjkU9YHit8sLHoJ1rp0DCCn6b=lXt

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-lagom-bundle" % "1.0.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-lagom-bundle" % "1.0.3")
 addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.2")


### PR DESCRIPTION
Update `sbt-lagom-bundle` to 1.0.3.

Also provides documentation for the `runtime-config.sh` which is part of the `front-end` bundle configuration. So it partially fixes the issue https://github.com/lagom/activator-lagom-java-chirper/issues/4. Once the video link has been added the issue can be closed. 
