### PR TITLE
Adds bundle publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,3 +109,11 @@ lazy val eclipseSettings = Seq(
 
 // do not delete database files on start
 lagomCassandraCleanOnStart in ThisBuild := false
+
+// set up information for where to publish our bundles to
+// (see http://conductr.lightbend.com/docs/1.1.x/CreatingBundles#Publishing-bundles for more
+// information)
+licenses in ThisBuild := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+bintrayVcsUrl in Bundle in ThisBuild := Some("https://github.com/lagom/activator-lagom-java-chirper")
+bintrayOrganization in Bundle in ThisBuild := Some("typesafe")
+bintrayReleaseOnPublish in Bundle in ThisBuild := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")


### PR DESCRIPTION
Adds the requisite lines in order to publish a bundle to bintray. These bundles then become available as easy as:

`conduct load friend-impl`

...given the ConductR CLI's resolver mechanism.
