### PR TITLE
Added .sbtopts file to prevent OOM - Re lagom/lagom#32

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms512M
+-J-Xmx4096M
+-J-Xss2M
+-J-XX:MaxMetaspaceSize=1024M


### PR DESCRIPTION
Note that -XX:MaxMetaspaceSize is set because of Activator. The issue is that
Activator sets the max metaspace size to 256M, and that is a too small value
even when running the chirper template. I've increased the value to 1Gb, and I'm
checking with the Activator team if they can avoid setting the max metaspace
size.
