### PR TITLE
Update Lagom to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val friendImpl = project("friend-impl")
   .settings(
     version := "1.0-SNAPSHOT",
     libraryDependencies ++= Seq(
-      lagomJavadslPersistence,
+      lagomJavadslPersistenceCassandra,
       lagomJavadslTestKit
     )
   )
@@ -35,7 +35,7 @@ lazy val chirpImpl = project("chirp-impl")
   .settings(
     version := "1.0-SNAPSHOT",
     libraryDependencies ++= Seq(
-      lagomJavadslPersistence,
+      lagomJavadslPersistenceCassandra,
       lagomJavadslPubSub,
       lagomJavadslTestKit
     )

--- a/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
+++ b/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
@@ -27,7 +27,7 @@ public class ChirpServiceTest {
 
   @BeforeClass
   public static void setUp() {
-    server = startServer(defaultSetup());
+    server = startServer(defaultSetup().withCassandra(true));
   }
 
   @AfterClass

--- a/friend-impl/src/main/java/sample/chirper/friend/impl/FriendEventProcessor.java
+++ b/friend-impl/src/main/java/sample/chirper/friend/impl/FriendEventProcessor.java
@@ -3,97 +3,77 @@
  */
 package sample.chirper.friend.impl;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSideProcessor;
+import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor;
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSide;
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession;
 
 import akka.Done;
+import org.pcollections.PSequence;
+import org.pcollections.TreePVector;
 import sample.chirper.friend.impl.FriendEvent.FriendAdded;
 
-public class FriendEventProcessor extends CassandraReadSideProcessor<FriendEvent> {
+import javax.inject.Inject;
+
+import static com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSide.completedStatement;
+
+public class FriendEventProcessor extends ReadSideProcessor<FriendEvent> {
+
+  private final CassandraSession session;
+  private final CassandraReadSide readSide;
 
   private PreparedStatement writeFollowers = null; // initialized in prepare
-  private PreparedStatement writeOffset = null; // initialized in prepare
+
+  @Inject
+  public FriendEventProcessor(CassandraSession session, CassandraReadSide readSide) {
+    this.session = session;
+    this.readSide = readSide;
+  }
 
   private void setWriteFollowers(PreparedStatement writeFollowers) {
     this.writeFollowers = writeFollowers;
   }
 
-  private void setWriteOffset(PreparedStatement writeOffset) {
-    this.writeOffset = writeOffset;
+  @Override
+  public PSequence<AggregateEventTag<FriendEvent>> aggregateTags() {
+    return TreePVector.singleton(FriendEventTag.INSTANCE);
   }
 
   @Override
-  public AggregateEventTag<FriendEvent> aggregateTag() {
-    return FriendEventTag.INSTANCE;
+  public ReadSideHandler<FriendEvent> buildHandler() {
+    return readSide.<FriendEvent>builder("friend_offset")
+            .setGlobalPrepare(this::prepareCreateTables)
+            .setPrepare((ignored) -> prepareWriteFollowers())
+            .setEventHandler(FriendAdded.class, this::processFriendChanged)
+            .build();
   }
 
-  @Override
-  public CompletionStage<Optional<UUID>> prepare(CassandraSession session) {
-    // @formatter:off
-    return
-      prepareCreateTables(session).thenCompose(a ->
-      prepareWriteFollowers(session).thenCompose(b ->
-      prepareWriteOffset(session).thenCompose(c ->
-      selectOffset(session))));
-    // @formatter:on
-  }
-
-  private CompletionStage<Done> prepareCreateTables(CassandraSession session) {
+  private CompletionStage<Done> prepareCreateTables() {
     // @formatter:off
     return session.executeCreateTable(
         "CREATE TABLE IF NOT EXISTS follower ("
           + "userId text, followedBy text, "
-          + "PRIMARY KEY (userId, followedBy))")
-      .thenCompose(a -> session.executeCreateTable(
-        "CREATE TABLE IF NOT EXISTS friend_offset ("
-          + "partition int, offset timeuuid, "
-          + "PRIMARY KEY (partition))"));
+          + "PRIMARY KEY (userId, followedBy))");
     // @formatter:on
   }
 
-  private CompletionStage<Done> prepareWriteFollowers(CassandraSession session) {
+  private CompletionStage<Done> prepareWriteFollowers() {
     return session.prepare("INSERT INTO follower (userId, followedBy) VALUES (?, ?)").thenApply(ps -> {
       setWriteFollowers(ps);
       return Done.getInstance();
     });
   }
 
-  private CompletionStage<Done> prepareWriteOffset(CassandraSession session) {
-    return session.prepare("INSERT INTO friend_offset (partition, offset) VALUES (1, ?)").thenApply(ps -> {
-      setWriteOffset(ps);
-      return Done.getInstance();
-    });
-  }
-
-  private CompletionStage<Optional<UUID>> selectOffset(CassandraSession session) {
-    return session.selectOne("SELECT offset FROM friend_offset WHERE partition=1")
-        .thenApply(
-        optionalRow -> optionalRow.map(r -> r.getUUID("offset")));
-  }
-
-  @Override
-  public EventHandlers defineEventHandlers(EventHandlersBuilder builder) {
-    builder.setEventHandler(FriendAdded.class, this::processFriendChanged);
-    return builder.build();
-  }
-
-  private CompletionStage<List<BoundStatement>> processFriendChanged(FriendAdded event, UUID offset) {
+  private CompletionStage<List<BoundStatement>> processFriendChanged(FriendAdded event) {
     BoundStatement bindWriteFollowers = writeFollowers.bind();
     bindWriteFollowers.setString("userId", event.friendId);
     bindWriteFollowers.setString("followedBy", event.userId);
-    BoundStatement bindWriteOffset = writeOffset.bind(offset);
-    return completedStatements(Arrays.asList(bindWriteFollowers, bindWriteOffset));
+    return completedStatement(bindWriteFollowers);
   }
-
-
 
 }

--- a/friend-impl/src/main/java/sample/chirper/friend/impl/FriendServiceImpl.java
+++ b/friend-impl/src/main/java/sample/chirper/friend/impl/FriendServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import com.lightbend.lagom.javadsl.persistence.ReadSide;
 import org.pcollections.PSequence;
 import org.pcollections.TreePVector;
 
@@ -16,7 +17,6 @@ import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.api.transport.NotFound;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntityRef;
 import com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry;
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSide;
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession;
 
 import akka.NotUsed;
@@ -33,7 +33,7 @@ public class FriendServiceImpl implements FriendService {
   private final CassandraSession db;
 
   @Inject
-  public FriendServiceImpl(PersistentEntityRegistry persistentEntities, CassandraReadSide readSide,
+  public FriendServiceImpl(PersistentEntityRegistry persistentEntities, ReadSide readSide,
       CassandraSession db) {
     this.persistentEntities = persistentEntities;
     this.db = db;

--- a/friend-impl/src/test/java/sample/chirper/friend/impl/FriendServiceTest.java
+++ b/friend-impl/src/test/java/sample/chirper/friend/impl/FriendServiceTest.java
@@ -21,7 +21,7 @@ public class FriendServiceTest {
 
   @Test
   public void shouldBeAbleToCreateUsersAndConnectFriends() throws Exception {
-    withServer(defaultSetup(), server -> {
+    withServer(defaultSetup().withCassandra(true), server -> {
       FriendService friendService = server.client(FriendService.class);
       User usr1 = new User("usr1", "User 1");
       friendService.createUser().invoke(usr1).toCompletableFuture().get(10, SECONDS);

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.2.0")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.9")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.16")
 


### PR DESCRIPTION
Includes migration of the read side, plus an update to the `sbt-conductr` plugin.