### PR TITLE
Refer to jsx executable by the actual path installed in node_modules

### DIFF
--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -184,7 +184,7 @@
                         <goal>exec</goal>
                     </goals>
                     <configuration>
-                        <executable>${basedir}/target/node/bin/jsx</executable>
+                        <executable>${basedir}/target/node/lib/node_modules/react-tools/bin/jsx</executable>
                         <environmentVariables>
                             <PATH>${env.PATH}:${pom.basedir}/target/node/node</PATH>
                         </environmentVariables>


### PR DESCRIPTION
This will ensure correct path being referenced in Linux/MacOS vs Windows.

This is due to difference of the executable location being placed by NPM. In Linux/MacOS the executable will be placed on `{prefix}/bin` while, on Windows it's `{prefix}`.

https://docs.npmjs.com/files/folders#executables