### PR TITLE
Use babel instead of deprecated react-tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.log
 
+# npm
+node_modules/
+
 # sbt specific
 .cache
 .history
@@ -18,6 +21,7 @@ project/plugins/project/
 .classpath
 .project
 .settings
+bin/
 
 # IDEA specific
 .idea

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 
 A Lagom Java template for Lightbend Activator showcasing a twitter-like application
 
+Start all services using `mvn lagom:runAll`.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 
 A Lagom Java template for Lightbend Activator showcasing a twitter-like application
 
-Start all services using `mvn lagom:runAll`.
+Start all services using `mvn lagom:runAll` or `sbt runAll`.

--- a/front-end/.babelrc
+++ b/front-end/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-jsx"]
+}

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lagom-java-chirper",
+  "description": "Lagom Java Chirper",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lagom/activator-lagom-java-chirper.git"
+  },
+  "license": "Apache 2",
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-plugin-transform-react-jsx": "^6.24.1"
+  }
+}

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-react-jsx": "^6.24.1"
+  },
+  "scripts": {
+    "babel": "babel"
   }
 }

--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -169,34 +169,20 @@
                             <arguments>install</arguments>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                  <execution>
-                    <id>compile .jsx files</id>
-                    <phase>generate-sources</phase>
-                    <goals>
-                        <goal>exec</goal>
-                    </goals>
-                    <configuration>
-                        <executable>node</executable>
-                        <environmentVariables>
-                            <PATH>${env.PATH}:${pom.basedir}/target/node/node</PATH>
-                        </environmentVariables>
-                        <arguments>
-                            <argument>${basedir}/node_modules/babel-cli/bin/babel.js</argument>
-                            <argument>${basedir}/src/main/resources/assets</argument>
-                            <argument>--out-dir</argument>
-                            <argument>${basedir}/target/classes/public</argument>
-                        </arguments>
-                        <!-- Need to pipe the output of the exec plugin into file, else the hot reload functionality won't work -->
-                        <outputFile>${java.io.tmpdir}/jsx-compile.txt</outputFile>
-                    </configuration>
-                  </execution>
+                    <execution>
+                        <id>compile .jsx files</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>
+                                run-script babel --
+                                ${basedir}/src/main/resources/assets
+                                --out-dir ${basedir}/target/classes/public
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -147,7 +147,6 @@
                 <version>1.4</version>
                 <configuration>
                     <installDirectory>${pom.basedir}/target/node</installDirectory>
-                    <workingDirectory>${pom.basedir}/target/node</workingDirectory>
                 </configuration>
                 <executions>
                     <execution>
@@ -161,13 +160,13 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>install .jsx compiler</id>
+                        <id>npm install</id>
                         <phase>initialize</phase>
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install -g react-tools</arguments>
+                            <arguments>install</arguments>
                         </configuration>
                     </execution>
                 </executions>
@@ -184,14 +183,14 @@
                         <goal>exec</goal>
                     </goals>
                     <configuration>
-                        <executable>${basedir}/target/node/bin/jsx</executable>
+                        <executable>node</executable>
                         <environmentVariables>
                             <PATH>${env.PATH}:${pom.basedir}/target/node/node</PATH>
                         </environmentVariables>
                         <arguments>
-                            <argument>--extension</argument>
-                            <argument>jsx</argument>
+                            <argument>${basedir}/node_modules/babel-cli/bin/babel.js</argument>
                             <argument>${basedir}/src/main/resources/assets</argument>
+                            <argument>--out-dir</argument>
                             <argument>${basedir}/target/classes/public</argument>
                         </arguments>
                         <!-- Need to pipe the output of the exec plugin into file, else the hot reload functionality won't work -->


### PR DESCRIPTION
Fixes https://github.com/lagom/activator-lagom-java-chirper/issues/56

`react-tools` is deprecated. It's sure to be only a matter of time until using it causes problems. Using babel is a much more standard way of setting up the project and so is much more useful to people who want to see what a project setup actually looks like in real life

Takes an extra 6s to setup the very first time you run the app. 4s faster every subsequent time you do a clean compile because it stops storing the node modules in the target directory where they're easily wiped out and instead uses the standard location