### PR TITLE
Fix chirper maven build issues

### DIFF
--- a/activity-stream-impl/pom.xml
+++ b/activity-stream-impl/pom.xml
@@ -102,7 +102,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$ACTIVITY_STREAM_BIND_IP" -Dhttp.port="$ACTIVITY_STREAM_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/chirp-impl/pom.xml
+++ b/chirp-impl/pom.xml
@@ -92,7 +92,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$CHIRP_BIND_IP" -Dhttp.port="$CHIRP_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/friend-impl/pom.xml
+++ b/friend-impl/pom.xml
@@ -88,7 +88,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$FRIEND_BIND_IP" -Dhttp.port="$FRIEND_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -209,7 +209,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$FRONT_END_BIND_IP" -Dhttp.port="$FRONT_END_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$WEB_BIND_IP" -Dhttp.port="$WEB_BIND_PORT" play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/load-test-impl/pom.xml
+++ b/load-test-impl/pom.xml
@@ -107,7 +107,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$LOAD_TEST_BIND_IP" -Dhttp.port="$LOAD_TEST_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$LOADTESTSERVICE_BIND_IP" -Dhttp.port="$LOADTESTSERVICE_BIND_PORT" play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/mvn-install
+++ b/mvn-install
@@ -6,40 +6,37 @@ which mvn &>/dev/null || (echo '* maven not found; did you install it?' && exit 
 which docker &>/dev/null || (echo '* docker not found; did you install it?' && exit 2)
 which sandbox &>/dev/null || (echo '* sandbox not found; did you install the ConductR Developer Sandbox?' && exit 2)
 
-echo "* building project"
+echo "Building project"
 
 mvn clean package docker:build
 
-echo "* starting sandbox"
+echo "Starting sandbox"
 
-sandbox run 2.1.0-alpha.1
+sandbox run 2.1.0-alpha.4
 
-echo "* loading cassandra..."
-CASSANDRA_ID=$(conduct load cassandra --long-ids -q)
+echo "Deploying cassandra..."
+CASSANDRA_BUNDLE_ID=$(conduct load cassandra --long-ids -q)
+conduct run ${CASSANDRA_BUNDLE_ID} --no-wait -q
 
-echo "* loading activity-stream"
-ACTIVITY_STREAM_ID="$(docker save chirper/activity-stream-impl | bndl --no-default-check --endpoint activity-stream --endpoint akka-remote | conduct load --long-ids -q)"
+echo "Deploying friend-impl..."
+FRIEND_IMPL_BUNDLE_ID="$(docker save chirper/friend-impl | bndl --no-default-check --endpoint friendservice --bind-protocol http --bind-port 0 --service-name friendservice --acl http:/api/users --endpoint akka-remote | conduct load --long-ids -q)"
+conduct run "$FRIEND_IMPL_BUNDLE_ID" --no-wait -q
 
-echo "* loading chirp"
-CHIRP_ID="$(docker save chirper/chirp-impl | bndl --no-default-check --endpoint chirp --endpoint akka-remote | conduct load --long-ids -q)"
+echo "Deploying load-test-impl"
+LOAD_TEST_IMPL_BUNDLE_ID="$(docker save chirper/load-test-impl | bndl --no-default-check --endpoint loadtestservice --bind-protocol http --bind-port 0 --service-name loadtestservice --endpoint akka-remote | conduct load --long-ids -q)"
+conduct run "$LOAD_TEST_IMPL_BUNDLE_ID" --no-wait -q
 
-echo "* loading friend"
-FRIEND_ID="$(docker save chirper/friend-impl | bndl --no-default-check --endpoint friend --endpoint akka-remote | conduct load --long-ids -q)"
+echo "Deploying chirp-impl..."
+CHIRP_IMPL_BUNDLE_ID="$(docker save chirper/chirp-impl | bndl --no-default-check --endpoint chirpservice --bind-protocol http --bind-port 0 --service-name chirpservice --acl http:/api/chirps/live --acl http:/api/chirps/history --endpoint akka-remote | conduct load --long-ids -q)"
+conduct run "$CHIRP_IMPL_BUNDLE_ID" --no-wait -q
 
-echo "* loading front-end"
-FRONT_END_ID="$(docker save chirper/front-end | bndl --no-default-check --endpoint front-end --endpoint akka-remote | conduct load --long-ids -q)"
+echo "Deploying activity-stream-impl..."
+ACTIVITY_STREAM_ID="$(docker save chirper/activity-stream-impl | bndl --no-default-check --endpoint activityservice --bind-protocol http --bind-port 0 --service-name activityservice --acl http:/api/activity --endpoint akka-remote | conduct load --long-ids -q)"
+conduct run "$ACTIVITY_STREAM_ID" --no-wait -q
 
-echo "* running cassandra"
-conduct run ${CASSANDRA_ID} --no-wait -q
+echo "Deploying front-end..."
+FRONT_END_BUNDLE_ID="$(docker save chirper/front-end | bndl --no-default-check --endpoint web --bind-protocol http --bind-port 0 --service-name web --acl http:/ --endpoint akka-remote | conduct load --long-ids -q)"
+conduct run "$FRONT_END_BUNDLE_ID" --no-wait -q
 
-echo "* running activity-stream"
-conduct run "$ACTIVITY_STREAM_ID"
-
-echo "* running chirp"
-conduct run "$CHIRP_ID"
-
-echo "* running friend"
-conduct run "$FRIEND_ID"
-
-echo "* running front-end"
-conduct run "$FRONT_END_ID"
+echo 'Your system is deployed. Running "conduct info" to observe the cluster.'
+conduct info

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>com.typesafe.conductr</groupId>
                 <artifactId>${conductr.lib.name}</artifactId>
-                <version>1.4.7</version>
+                <version>1.9.1</version>
             </dependency>
             <!-- front-end webjars -->
             <dependency>
@@ -137,7 +137,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <lagom.version>1.3.2</lagom.version>
-        <conductr.lib.name>lagom10-conductr-bundle-lib_2.11</conductr.lib.name>
+        <lagom.version>1.3.4</lagom.version>
+        <conductr.lib.name>lagom1-java-conductr-bundle-lib_2.11</conductr.lib.name>
     </properties>
 </project>


### PR DESCRIPTION
This fixes various issues with the Maven build that were discovered when attempting to run via ConductR's OCI-in-Docker support. It also renames the services to directly match the SBT generated installation script and modifies the `mvn-install` script to deploy services in a similiar manner.