### PR TITLE
Set BUILD_SYSTEM explicitly on sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,8 @@ lazy val frontEnd = project("front-end")
       (sourceDirectory in Assets).value :+
       (resourceDirectory in Assets).value,
 
+    WebpackKeys.envVars in webpack += "BUILD_SYSTEM" -> "sbt",
+
     // Remove to use Scala IDE
     EclipseKeys.createSrc := EclipseCreateSrc.ValueSet(EclipseCreateSrc.ManagedClasses, EclipseCreateSrc.ManagedResources)
   )


### PR DESCRIPTION
Previously, it was only ever set to "maven" and assumed to be sbt if it was not set to "maven".

This sets it from `sbt` as well for clarity and consistency.

The `BUILD_SYSTEM` environment variable is used by our Webpack front-end build to handle any differences between sbt and Maven.