### PR TITLE
Ensure the sbt build matrix job runs sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.m2
     - $HOME/.ivy2/cache
     - $HOME/.nvm
+    - $HOME/.sbt/launchers
 before_cache:
   # Ensure changes to the cache aren't persisted
   - rm -rf $HOME/.m2/repository/com/lightbend/lagom/sample/chirper

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
   directories:
     - $HOME/.m2
     - $HOME/.ivy2/cache
+    - $HOME/.nvm
 before_cache:
   # Ensure changes to the cache aren't persisted
   - rm -rf $HOME/.m2/repository/com/lightbend/lagom/sample/chirper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
-language: java
+language: scala
 sudo: false
 jdk:
   - oraclejdk8
+# This skips the install step.
+# See https://docs.travis-ci.com/user/customizing-the-build#Skipping-the-Installation-Ste
+install: true
+script: $SCRIPT
 env:
   matrix:
-    - SCRIPT="mvn test"
-    - SCRIPT="sbt test"
+    - SCRIPT="mvn test -B"
+    - SCRIPT="sbt -batch test"
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script: $SCRIPT
 env:
   matrix:
     - SCRIPT="mvn test -B"
-    - SCRIPT="sbt -batch test"
+    - SCRIPT="./sbt-build"
 cache:
   directories:
     - $HOME/.m2

--- a/sbt-build
+++ b/sbt-build
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Ensure this script fails on all errors
+set -eo pipefail
+
+wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+nvm install --lts
+
+sbt -batch test


### PR DESCRIPTION
Previously, both jobs ran mvn by default. The `SCRIPT` environment variable was not used, and the build script used Travis CI's default auto-detection.

Fixes #68