### PR TITLE
Kubernetes Deployment

### DIFF
--- a/DeployKubernetesMiniKube.md
+++ b/DeployKubernetesMiniKube.md
@@ -1,0 +1,138 @@
+# Minikube setup
+
+Start `minikube`.
+
+```
+minikube start
+```
+
+Setup docker env.
+
+```
+eval $(minikube docker-env)
+```
+
+# Deploy Cassandra
+
+Based on https://github.com/kubernetes/kubernetes/tree/master/examples/storage/cassandra
+
+## Setup
+
+Pull the Cassandra docker image.
+
+```
+docker pull gcr.io/google-samples/cassandra:v12
+```
+
+## Declare Cassandra endpoints
+
+Create Service to expose Cassandra endpoints.
+
+```
+kubectl create -f deploy/k8/minikube/cassandra/cassandra-service.yaml
+```
+
+Observe the created Service.
+
+```
+kubectl get svc cassandra
+```
+
+## Create Cassandra ring
+
+Since we're using minikube:
+
+* Only 1 instance.
+* No persistent volume.
+
+```
+kubectl create -f deploy/k8/minikube/cassandra/cassandra-statefulset.yaml
+```
+
+Observe the created StatefulSet.
+
+```
+kubectl get statefulset cassandra
+```
+
+## Check Cassandra running
+
+Cassandra should be running now.
+
+```
+kubectl get pods -l="app=cassandra"
+```
+
+Example output:
+
+```
+NAME          READY     STATUS    RESTARTS   AGE
+cassandra-0   1/1       Running   0          1m
+```
+
+Run Cassandra `nodetool`.
+
+```
+kubectl exec cassandra-0 -- nodetool status
+```
+
+Example output:
+
+```
+Datacenter: DC1-K8Demo
+======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address     Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  172.17.0.5  99.45 KiB  32           100.0%            446361b8-d005-4525-8830-04d23a43d6aa  Rack1-K8Demo
+```
+
+# Publish Chirper
+
+Publish Chirper docker images to `minikube`'s Docker registry.
+
+```
+mvn clean package docker:build
+```
+
+Once done, check if images has been published.
+
+```
+docker images
+```
+
+Expected output should be similar to the following.
+
+```
+REPOSITORY                                             TAG                 IMAGE ID            CREATED             SIZE
+chirper/front-end                                      1.0-SNAPSHOT        1a8ff0f4ba3c        18 minutes ago      145 MB
+chirper/front-end                                      latest              1a8ff0f4ba3c        18 minutes ago      145 MB
+chirper/load-test-impl                                 1.0-SNAPSHOT        b01800ca5d47        18 minutes ago      150 MB
+chirper/load-test-impl                                 latest              b01800ca5d47        18 minutes ago      150 MB
+chirper/activity-stream-impl                           1.0-SNAPSHOT        92e1f3060e8b        18 minutes ago      150 MB
+chirper/activity-stream-impl                           latest              92e1f3060e8b        18 minutes ago      150 MB
+chirper/chirp-impl                                     1.0-SNAPSHOT        a15defc9e551        18 minutes ago      150 MB
+chirper/chirp-impl                                     latest              a15defc9e551        18 minutes ago      150 MB
+chirper/friend-impl                                    1.0-SNAPSHOT        cee7f72a23ad        19 minutes ago      150 MB
+chirper/friend-impl                                    latest              cee7f72a23ad        19 minutes ago      150 MB
+```
+
+# Deploy Friend Service
+
+Deploy the Friend Service.
+
+```
+kubectl create -f deploy/k8/minikube/lagom/friend-impl/friend-impl-statefulset.json
+```
+
+Check deploy status.
+
+```
+kubectl get pods -l="app=friendservice"
+```
+
+View the complete pod status.
+
+```
+kubectl describe pod friendservice
+```

--- a/activity-stream-impl/pom.xml
+++ b/activity-stream-impl/pom.xml
@@ -54,9 +54,10 @@
             <artifactId>lagom-javadsl-testkit_2.11</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Service Locator Provider -->
         <dependency>
-            <groupId>com.typesafe.conductr</groupId>
-            <artifactId>${conductr.lib.name}</artifactId>
+            <groupId>${serviceLocator.provider.groupName}</groupId>
+            <artifactId>${serviceLocator.provider.artifactName}</artifactId>
         </dependency>
     </dependencies>
 
@@ -102,7 +103,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-activityservice-v1}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" -Dakka.cluster.seed-nodes.0="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST}:${AKKA_SEED_NODE_PORT}" -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/activity-stream-impl/src/main/resources/application.conf
+++ b/activity-stream-impl/src/main/resources/application.conf
@@ -1,1 +1,18 @@
 play.modules.enabled += sample.chirper.activity.impl.ActivityStreamModule
+
+
+service-locator-dns {
+  name-translators = [
+    {
+      "^_.+$" = "$0",
+      "^.*$" = "_http-lagom-api._tcp.$0.default.svc.cluster.local"
+    }
+  ]
+
+  srv-translators = [
+    {
+      "^_http-lagom-api[.]_tcp[.](.+)$" = "_http-lagom-api._http.$1",
+      "^.*$" = "$0"
+    }
+  ]
+}

--- a/chirp-impl/pom.xml
+++ b/chirp-impl/pom.xml
@@ -44,9 +44,10 @@
             <artifactId>lagom-javadsl-testkit_2.11</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Service Locator Provider -->
         <dependency>
-            <groupId>com.typesafe.conductr</groupId>
-            <artifactId>${conductr.lib.name}</artifactId>
+            <groupId>${serviceLocator.provider.groupName}</groupId>
+            <artifactId>${serviceLocator.provider.artifactName}</artifactId>
         </dependency>
     </dependencies>
 
@@ -92,7 +93,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-chirpservice-v1}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" -Dakka.cluster.seed-nodes.0="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST}:${AKKA_SEED_NODE_PORT}" -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/deploy/kubernetes/resources/cassandra/cassandra-service.json
+++ b/deploy/kubernetes/resources/cassandra/cassandra-service.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "cassandra"
+    },
+    "name": "cassandra"
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "native",
+        "port": 9042
+      }
+    ],
+    "selector": {
+      "app": "cassandra"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/cassandra/cassandra-statefulset.json
+++ b/deploy/kubernetes/resources/cassandra/cassandra-statefulset.json
@@ -1,0 +1,130 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "cassandra"
+  },
+  "spec": {
+    "serviceName": "cassandra",
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "cassandra"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "cassandra",
+            "image": "gcr.io/google-samples/cassandra:v12",
+            "imagePullPolicy": "Always",
+            "ports": [
+              {
+                "containerPort": 7000,
+                "name": "intra-node"
+              },
+              {
+                "containerPort": 7001,
+                "name": "tls-intra-node"
+              },
+              {
+                "containerPort": 7199,
+                "name": "jmx"
+              },
+              {
+                "containerPort": 9042,
+                "name": "native"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "250m",
+                "memory": "1Gi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "1Gi"
+              }
+            },
+            "securityContext": {
+              "capabilities": {
+                "add": [
+                  "IPC_LOCK"
+                ]
+              }
+            },
+            "lifecycle": {
+              "preStop": {
+                "exec": {
+                  "command": [
+                    "/bin/sh",
+                    "-c",
+                    "PID=$(pidof java) && kill $PID && while ps -p $PID > /dev/null; do sleep 1; done"
+                  ]
+                }
+              }
+            },
+            "env": [
+              {
+                "name": "MAX_HEAP_SIZE",
+                "value": "512M"
+              },
+              {
+                "name": "HEAP_NEWSIZE",
+                "value": "100M"
+              },
+              {
+                "name": "CASSANDRA_SEEDS",
+                "value": "cassandra-0.cassandra.default.svc.cluster.local"
+              },
+              {
+                "name": "CASSANDRA_CLUSTER_NAME",
+                "value": "K8Demo"
+              },
+              {
+                "name": "CASSANDRA_DC",
+                "value": "DC1-K8Demo"
+              },
+              {
+                "name": "CASSANDRA_RACK",
+                "value": "Rack1-K8Demo"
+              },
+              {
+                "name": "CASSANDRA_AUTO_BOOTSTRAP",
+                "value": "false"
+              },
+              {
+                "name": "POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "readinessProbe": {
+              "exec": {
+                "command": [
+                  "/bin/bash",
+                  "-c",
+                  "/ready-probe.sh"
+                ]
+              },
+              "initialDelaySeconds": 15,
+              "timeoutSeconds": 5
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/activity-stream-impl-service-akka-remoting.json
+++ b/deploy/kubernetes/resources/chirper/activity-stream-impl-service-akka-remoting.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "activityservice"
+    },
+    "name": "activityservice-akka-remoting"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 2551,
+        "protocol": "TCP",
+        "targetPort": 2551
+      }
+    ],
+    "selector": {
+      "app": "activityservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/activity-stream-impl-service.json
+++ b/deploy/kubernetes/resources/chirper/activity-stream-impl-service.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "activityservice"
+    },
+    "name": "activityservice"
+  },
+  "spec": {
+    "clusterIP": "None",
+    "ports": [
+      {
+        "name": "http-lagom-api",
+        "port": 9000,
+        "protocol": "TCP",
+        "targetPort": 9000
+      }
+    ],
+    "selector": {
+      "app": "activityservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "activityservice"
+  },
+  "spec": {
+    "serviceName": "activityservice",
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "activityservice"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "activityservice",
+            "image": "chirper/activity-stream-impl",
+            "imagePullPolicy": "Never",
+            "ports": [
+              {
+                "containerPort": 9000,
+                "name": "http-lagom-api"
+              },
+              {
+                "containerPort": 2551,
+                "name": "akka-remote"
+              }
+            ],
+            "env": [
+              {
+                "name": "CASSANDRA_SERVICE_NAME",
+                "value": "_native._tcp.cassandra.default.svc.cluster.local"
+              },
+              {
+                "name": "APPLICATION_SECRET",
+                "value": "activityservice-application-secret"
+              },
+              {
+                "name": "ACTIVITYSERVICE_BIND_PORT",
+                "value": "9000"
+              },
+              {
+                "name": "ACTIVITYSERVICE_BIND_IP",
+                "value": "0.0.0.0"
+              },
+              {
+                "name": "AKKA_ACTOR_SYSTEM_NAME",
+                "value": "activityservice-v1"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_HOST",
+                "value": "$HOSTNAME.activityservice.default.svc.cluster.local"
+              },
+              {
+                "name": "AKKA_SEED_NODE_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_SEED_NODE_HOST",
+                "value": "activityservice-0.activityservice.default.svc.cluster.local"
+              },
+              {
+                "name": "POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/_status/circuit-breaker/current",
+                "port": 9000
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 5
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/chirp-impl-service-akka-remoting.json
+++ b/deploy/kubernetes/resources/chirper/chirp-impl-service-akka-remoting.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "chirpservice"
+    },
+    "name": "chirpservice-akka-remoting"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 2551,
+        "protocol": "TCP",
+        "targetPort": 2551
+      }
+    ],
+    "selector": {
+      "app": "chirpservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/chirp-impl-service.json
+++ b/deploy/kubernetes/resources/chirper/chirp-impl-service.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "chirpservice"
+    },
+    "name": "chirpservice"
+  },
+  "spec": {
+    "clusterIP": "None",
+    "ports": [
+      {
+        "name": "http-lagom-api",
+        "port": 9000,
+        "protocol": "TCP",
+        "targetPort": 9000
+      }
+    ],
+    "selector": {
+      "app": "chirpservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "chirpservice"
+  },
+  "spec": {
+    "serviceName": "chirpservice",
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "chirpservice"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "chirpservice",
+            "image": "chirper/chirp-impl",
+            "imagePullPolicy": "Never",
+            "ports": [
+              {
+                "containerPort": 9000,
+                "name": "http-lagom-api"
+              },
+              {
+                "containerPort": 2551,
+                "name": "akka-remote"
+              }
+            ],
+            "env": [
+              {
+                "name": "CASSANDRA_SERVICE_NAME",
+                "value": "_native._tcp.cassandra.default.svc.cluster.local"
+              },
+              {
+                "name": "APPLICATION_SECRET",
+                "value": "chirpservice-application-secret"
+              },
+              {
+                "name": "CHIRPSERVICE_BIND_PORT",
+                "value": "9000"
+              },
+              {
+                "name": "CHIRPSERVICE_BIND_IP",
+                "value": "0.0.0.0"
+              },
+              {
+                "name": "AKKA_ACTOR_SYSTEM_NAME",
+                "value": "chirpservice-v1"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_HOST",
+                "value": "$HOSTNAME.chirpservice.default.svc.cluster.local"
+              },
+              {
+                "name": "AKKA_SEED_NODE_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_SEED_NODE_HOST",
+                "value": "chirpservice-0.chirpservice.default.svc.cluster.local"
+              },
+              {
+                "name": "POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/_status/circuit-breaker/current",
+                "port": 9000
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 5
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/friend-impl-service-akka-remoting.json
+++ b/deploy/kubernetes/resources/chirper/friend-impl-service-akka-remoting.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "friendservice"
+    },
+    "name": "friendservice-akka-remoting"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 2551,
+        "protocol": "TCP",
+        "targetPort": 2551
+      }
+    ],
+    "selector": {
+      "app": "friendservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/friend-impl-service.json
+++ b/deploy/kubernetes/resources/chirper/friend-impl-service.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "friendservice"
+    },
+    "name": "friendservice"
+  },
+  "spec": {
+    "clusterIP": "None",
+    "ports": [
+      {
+        "name": "http-lagom-api",
+        "port": 9000,
+        "protocol": "TCP",
+        "targetPort": 9000
+      }
+    ],
+    "selector": {
+      "app": "friendservice"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
@@ -1,0 +1,99 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "friendservice"
+  },
+  "spec": {
+    "serviceName": "friendservice",
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "friendservice"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "friendservice",
+            "image": "chirper/friend-impl",
+            "imagePullPolicy": "Never",
+            "ports": [
+              {
+                "containerPort": 9000,
+                "name": "tcp-lagom-api"
+              },
+              {
+                "containerPort": 2551,
+                "name": "akka-remote"
+              }
+            ],
+            "env": [
+              {
+                "name": "CASSANDRA_SERVICE_NAME",
+                "value": "_native._tcp.cassandra.default.svc.cluster.local"
+              },
+              {
+                "name": "APPLICATION_SECRET",
+                "value": "friendservice-application-secret"
+              },
+              {
+                "name": "FRIENDSERVICE_BIND_PORT",
+                "value": "9000"
+              },
+              {
+                "name": "FRIENDSERVICE_BIND_IP",
+                "value": "0.0.0.0"
+              },
+              {
+                "name": "AKKA_ACTOR_SYSTEM_NAME",
+                "value": "friendservice-v1"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_REMOTING_BIND_HOST",
+                "value": "$HOSTNAME.friendservice.default.svc.cluster.local"
+              },
+              {
+                "name": "AKKA_SEED_NODE_PORT",
+                "value": "2551"
+              },
+              {
+                "name": "AKKA_SEED_NODE_HOST",
+                "value": "friendservice-0.friendservice.default.svc.cluster.local"
+              },
+              {
+                "name": "POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/_status/circuit-breaker/current",
+                "port": 9000
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 5
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/front-end-service.json
+++ b/deploy/kubernetes/resources/chirper/front-end-service.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "app": "web"
+    },
+    "name": "web"
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "http-play",
+        "port": 9000
+      }
+    ],
+    "selector": {
+      "app": "web"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/chirper/front-end-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/front-end-statefulset.json
@@ -1,0 +1,52 @@
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "web"
+  },
+  "spec": {
+    "serviceName": "web",
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "web"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "web",
+            "image": "chirper/front-end",
+            "imagePullPolicy": "Never",
+            "ports": [
+              { "containerPort": 9000 }
+            ],
+            "env": [
+              {
+                "name": "CASSANDRA_SERVICE_NAME",
+                "value": "_native._tcp.cassandra.default.svc.cluster.local"
+              },
+              {
+                "name": "WEB_BIND_PORT",
+                "value": "9000"
+              },
+              {
+                "name": "WEB_BIND_IP",
+                "value": "0.0.0.0"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/",
+                "port": 9000
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 5
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/istio/chirper-ingress.json
+++ b/deploy/kubernetes/resources/istio/chirper-ingress.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Ingress",
+  "metadata": {
+    "name": "chirper-ingress",
+    "annotations": {
+      "kubernetes.io/ingress.class": "istio"
+    }
+  },
+  "spec": {
+    "rules": [
+      {
+        "http": {
+          "paths": [
+            {
+              "path": "/api/activity.*",
+              "backend": {
+                "serviceName": "activityservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "path": "/api/users.*",
+              "backend": {
+                "serviceName": "friendservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "path": "/api/chirps.*",
+              "backend": {
+                "serviceName": "chirpservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "path": "/.*",
+              "backend": {
+                "serviceName": "web",
+                "servicePort": 9000
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/deploy/kubernetes/resources/nginx/chirper-ingress.json
+++ b/deploy/kubernetes/resources/nginx/chirper-ingress.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Ingress",
+  "metadata": {
+    "name": "chirper-ingress",
+    "annotations": {
+      "ingress.kubernetes.io/ssl-redirect": "false"
+    }
+  },
+  "spec": {
+    "tls": [
+      { "secretName": "chirper-tls-secret" }
+    ],
+    "rules": [
+      {
+        "http": {
+          "paths": [
+            {
+              "path": "/api/activity",
+              "backend": {
+                "serviceName": "activityservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "path": "/api/users",
+              "backend": {
+                "serviceName": "friendservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "path": "/api/chirps",
+              "backend": {
+                "serviceName": "chirpservice",
+                "servicePort": 9000
+              }
+            },
+            {
+              "backend": {
+                "serviceName": "web",
+                "servicePort": 9000
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/deploy/kubernetes/resources/nginx/nginx-default-backend-deployment.json
+++ b/deploy/kubernetes/resources/nginx/nginx-default-backend-deployment.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "nginx-default-backend"
+  },
+  "spec": {
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx-default-backend"
+        }
+      },
+      "spec": {
+        "terminationGracePeriodSeconds": 60,
+        "containers": [
+          {
+            "name": "nginx-default-backend",
+            "image": "gcr.io/google_containers/defaultbackend:1.0",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 5
+            },
+            "ports": [
+              {
+                "containerPort": 8080
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "20Mi"
+              },
+              "requests": {
+                "cpu": "10m"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/nginx/nginx-default-backend-service.json
+++ b/deploy/kubernetes/resources/nginx/nginx-default-backend-service.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "nginx-default-backend"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 80,
+        "targetPort": 8080
+      }
+    ],
+    "selector": {
+      "app": "nginx-default-backend"
+    }
+  }
+}

--- a/deploy/kubernetes/resources/nginx/nginx-deployment.json
+++ b/deploy/kubernetes/resources/nginx/nginx-deployment.json
@@ -1,0 +1,60 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "nginx-ingress-controller"
+  },
+  "spec": {
+    "replicas": 1,
+    "template": {
+      "metadata": {
+        "labels": {
+          "k8s-app": "nginx-ingress-lb"
+        }
+      },
+      "spec": {
+        "terminationGracePeriodSeconds": 60,
+        "containers": [
+          {
+            "name": "nginx-ingress-controller",
+            "image": "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.10",
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 18080,
+                "scheme": "HTTP"
+              }
+            },
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 18080,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 5
+            },
+            "args": [
+              "/nginx-ingress-controller",
+              "--default-backend-service=$(POD_NAMESPACE)/nginx-default-backend"
+            ],
+            "env": [
+              {
+                "name": "POD_NAME",
+                "valueFrom": { "fieldRef": { "fieldPath": "metadata.name" } }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": { "fieldRef": { "fieldPath": "metadata.namespace" } }
+              }
+            ],
+            "ports": [
+              { "containerPort": 80 },
+              { "containerPort": 443 }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/resources/nginx/nginx-service.json
+++ b/deploy/kubernetes/resources/nginx/nginx-service.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "nginx-ingress"
+  },
+  "spec": {
+    "type": "LoadBalancer",
+    "ports": [
+      {
+        "port": 80,
+        "name": "http"
+      },
+      {
+        "port": 443,
+        "name": "https"
+      }
+    ],
+    "selector": {
+      "k8s-app": "nginx-ingress-lb"
+    }
+  }
+}

--- a/deploy/kubernetes/scripts/install
+++ b/deploy/kubernetes/scripts/install
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+RESOURCES_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../resources" && pwd)"
+REGISTRY=""
+CONFIGURE_TLS=0
+DEPLOY_CASSANDRA=0
+BUILD_CHIRPER=0
+UPLOAD_CHIRPER=0
+DEPLOY_CHIRPER=0
+DELETE_CHIRPER=0
+DEPLOY_NGINX=0
+MINIKUBE=0
+MINIKUBE_RESET=0
+OPTION=""
+
+(which kubectl &>/dev/null) || (echo '* missing kubectl, is it installed?' && exit 1)
+(which bx &>/dev/null) || (echo '* missing bx, is it installed?' && exit 1)
+(which jq &>/dev/null) || (echo '* missing jq, is it installed?' && exit 1)
+(which docker &>/dev/null) || (echo '* missing docker; is it installed?' && exit 1)
+(which mvn &>/dev/null) || (echo '* missing mvn; is it installed?' && exit 1)
+
+if [[ "$#" -eq 0 ]]; then
+    echo "$0 [--minikube] [--new-minikube] [--registry REGISTRY] [--tls] [--cassandra] [--build] [--deploy] [--delete] [--nginx] [--all]" >&1
+    exit 1
+fi
+
+while test $# -gt 0; do
+    case "$1" in
+        --minikube)
+            (which minikube &>/dev/null) || (echo '* missing minikube; is it installed?' && exit 1)
+            MINIKUBE=1
+            REGISTRY=""
+            ;;
+        --new-minikube)
+            (which minikube &>/dev/null) || (echo '* missing minikube; is it installed?' && exit 1)
+            MINIKUBE=1
+            MINIKUBE_RESET=1
+            REGISTRY=""
+            ;;
+        --registry)
+            MINIKUBE=0
+            MINIKUBE_RESET=0
+            OPTION=REGISTRY
+            UPLOAD_CHIRPER=1
+            ;;
+        --tls)
+            CONFIGURE_TLS=1
+            ;;
+        --cassandra)
+            DEPLOY_CASSANDRA=1
+            ;;
+        --build)
+            BUILD_CHIRPER=1
+            ;;
+        --deploy)
+            DEPLOY_CHIRPER=1
+            ;;
+        --delete)
+            DELETE_CHIRPER=1
+            ;;
+        --nginx)
+            DEPLOY_NGINX=1
+            ;;
+        --all)
+            CONFIGURE_TLS=1
+            DEPLOY_CASSANDRA=1
+            BUILD_CHIRPER=1
+            DEPLOY_CHIRPER=1
+            DEPLOY_NGINX=1
+            ;;
+        --*)
+            >&2 echo "unknown option $1"
+            exit 1
+            ;;
+        *)
+            if [ "$OPTION" != "" ]; then
+                declare "$OPTION=$1"
+                OPTION=""
+            else
+                >&2 echo "unknown argument $1"
+                exit 1
+            fi
+            ;;
+    esac
+    shift
+done
+
+echo '****************************'
+echo '***  Summary             ***'
+echo '****************************'
+
+echo "Registry:          $([ "$REGISTRY" = "" ]        && echo "N/A" || echo "$REGISTRY")"
+echo "Minikube:          $([ "$MINIKUBE" = 1 ]         && echo "$([ "$MINIKUBE_RESET" = 1 ] && echo "New" || echo "Yes")" || echo "No")"
+echo "Configure TLS:     $([ "$CONFIGURE_TLS" = 1 ]    && echo "Yes" || echo "No")"
+echo "Deploy Cassandra:  $([ "$DEPLOY_CASSANDRA" = 1 ] && echo "Yes" || echo "No")"
+echo "Build Chirper:     $([ "$BUILD_CHIRPER" = 1 ]    && echo "Yes" || echo "No")"
+echo "Upload Chirper:    $([ "$UPLOAD_CHIRPER" = 1 ]   && echo "Yes" || echo "No")"
+echo "Delete Chirper:    $([ "$DELETE_CHIRPER" = 1 ]   && echo "Yes" || echo "No")"
+echo "Deploy Chirper:    $([ "$DEPLOY_CHIRPER" = 1 ]   && echo "Yes" || echo "No")"
+echo "Deploy nginx:      $([ "$DEPLOY_NGINX" = 1 ]     && echo "Yes" || echo "No")"
+echo
+
+echo 'Note: You must have kubectl setup to point to your Kubernetes cluster, and be logged into your Docker registry if applicable.'
+echo
+read -p 'Press anything to continue, or CTRL-C to exit'
+
+wait-for-pods() {
+    echo -n 'waiting...'
+    while (kubectl get pods 2>&1 | grep '0/\|1/2\|No resources') &>/dev/null; do echo -n '.' && sleep 1; done
+    echo
+}
+
+if [ "$MINIKUBE_RESET" = "1" ]; then
+    echo '****************************'
+    echo '***  Resetting minikube  ***'
+    echo '****************************'
+
+    (minikube delete || true) &>/dev/null
+
+    minikube start --memory 8192
+fi
+
+if [ "$MINIKUBE" = 1 ]; then
+    eval $(minikube docker-env)
+fi
+
+if [ "$CONFIGURE_TLS" = 1 ]; then
+    echo '****************************'
+    echo '***  Configuring TLS     ***'
+    echo '****************************'
+
+    SSL_TEMP_DIR="$(mktemp -d)"
+
+    openssl req \
+        -x509 -newkey rsa:2048 -nodes -days 365 \
+        -keyout "$SSL_TEMP_DIR/tls.key" -out "$SSL_TEMP_DIR/tls.crt" -subj "/CN=localhost"
+
+    kubectl create secret tls chirper-tls-secret "--cert=$SSL_TEMP_DIR/tls.crt" "--key=$SSL_TEMP_DIR/tls.key"
+
+    rm -rf "$SSL_TEMP_DIR"
+fi
+
+if [ "$DEPLOY_CASSANDRA" = 1 ]; then
+    echo '****************************'
+    echo '***  Deploying cassandra ***'
+    echo '****************************'
+
+    kubectl create -f "$RESOURCES_PATH/cassandra"
+    wait-for-pods
+fi
+
+if [ "$BUILD_CHIRPER" = 1 ]; then
+    echo '****************************'
+    echo '***  Building chirper    ***'
+    echo '****************************'
+
+    (cd "$RESOURCES_PATH/../../.." && mvn clean package docker:build)
+fi
+
+if [ "$UPLOAD_CHIRPER" = 1 ]; then
+    IMAGES=()
+    for file in $RESOURCES_PATH/chirper/*; do
+        image="$(jq -M -r ". | if .kind != \"StatefulSet\" then \"\" else .spec.template.spec.containers | map(.image)[0] end" "$file")"
+
+        if [ "$image" != "" ]; then
+            IMAGES+=("$image")
+        fi
+    done
+
+    echo '****************************'
+    echo '***  Uploading chirper   ***'
+    echo '****************************'
+
+    for image in "${IMAGES[@]}"; do
+        docker tag "$image" "$REGISTRY/$image"
+        docker push "$REGISTRY/$image"
+    done
+fi
+
+if [ "$DELETE_CHIRPER" = 1 ]; then
+    echo '****************************'
+    echo '***  Deleting chirper    ***'
+    echo '****************************'
+
+    for file in $RESOURCES_PATH/chirper/*; do
+        kubectl delete -f "$file"
+    done
+fi
+
+if [ "$DEPLOY_CHIRPER" = 1 ]; then
+    echo '****************************'
+    echo '***  Deploying chirper   ***'
+    echo '****************************'
+
+    for file in $RESOURCES_PATH/chirper/*; do
+        if [ "$REGISTRY" = "" ]; then
+            kubectl create -f "$file"
+        else
+            jq -M ". |
+                if .kind == \"StatefulSet\" then
+                    .spec.template.spec.containers |= map(
+                        .image = \"$REGISTRY/\" + .image |
+                        .imagePullPolicy = \"Always\"
+                    )
+                else
+                    .
+                end
+            " "$file" | kubectl create -f -
+        fi
+    done
+    wait-for-pods
+fi
+
+if [ "$DEPLOY_NGINX" = 1 ]; then
+    echo '****************************'
+    echo '***  Deploying nginx     ***'
+    echo '****************************'
+
+    kubectl create -f "$RESOURCES_PATH/nginx"
+    wait-for-pods
+fi
+
+kubectl get all
+
+if [ "$MINIKUBE" = 1 ]; then
+    echo
+    echo
+    echo "Chirper UI (HTTP): $(minikube service --url nginx-ingress | head -n 1)"
+    echo "Chirper UI (HTTPS): $(minikube service --url --https nginx-ingress | tail -n 1)"
+    echo "Kubernetes Dashboard: $(minikube dashboard --url)"
+fi

--- a/friend-impl/pom.xml
+++ b/friend-impl/pom.xml
@@ -40,9 +40,10 @@
             <artifactId>lagom-javadsl-testkit_2.11</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Service Locator Provider -->
         <dependency>
-            <groupId>com.typesafe.conductr</groupId>
-            <artifactId>${conductr.lib.name}</artifactId>
+            <groupId>${serviceLocator.provider.groupName}</groupId>
+            <artifactId>${serviceLocator.provider.artifactName}</artifactId>
         </dependency>
     </dependencies>
 
@@ -88,7 +89,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-friendservice-v1}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" -Dakka.cluster.seed-nodes.0="akka.tcp://${AKKA_ACTOR_SYSTEM_NAME}@${AKKA_SEED_NODE_HOST}:${AKKA_SEED_NODE_PORT}" -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -46,9 +46,10 @@
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-netty-server_2.11</artifactId>
         </dependency>
+        <!-- Service Locator Provider -->
         <dependency>
-            <groupId>com.typesafe.conductr</groupId>
-            <artifactId>${conductr.lib.name}</artifactId>
+            <groupId>${serviceLocator.provider.groupName}</groupId>
+            <artifactId>${serviceLocator.provider.artifactName}</artifactId>
         </dependency>
     </dependencies>
 

--- a/front-end/src/main/resources/assets/circuitbreaker.jsx
+++ b/front-end/src/main/resources/assets/circuitbreaker.jsx
@@ -6,7 +6,8 @@ import { IndexRoute, Link, Route, Router } from 'react-router'
 function createCircuitBreakerStream(serviceHostPort, onopen) {
     return {
         connect: function(onEvent) {
-            var stream = new WebSocket("ws://" + serviceHostPort + "/_status/circuit-breaker/stream");
+            var protocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
+            var stream = new WebSocket(protocol + serviceHostPort + "/_status/circuit-breaker/stream");
             if (onopen) {
                 stream.onopen = function(event) {
                     onopen(stream, event);

--- a/front-end/src/main/resources/assets/main.jsx
+++ b/front-end/src/main/resources/assets/main.jsx
@@ -64,7 +64,8 @@ function createActivityStream(userId) {
 function createStream(path, onopen) {
     return {
         connect: function(onChirp) {
-            var stream = new WebSocket("ws://" + location.host + path);
+            var protocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
+            var stream = new WebSocket(protocol + location.host + path);
             if (onopen) {
                 stream.onopen = function(event) {
                     onopen(stream, event);

--- a/load-test-impl/pom.xml
+++ b/load-test-impl/pom.xml
@@ -59,9 +59,10 @@
             <artifactId>lagom-javadsl-testkit_2.11</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Service Locator Provider -->
         <dependency>
-            <groupId>com.typesafe.conductr</groupId>
-            <artifactId>${conductr.lib.name}</artifactId>
+            <groupId>${serviceLocator.provider.groupName}</groupId>
+            <artifactId>${serviceLocator.provider.artifactName}</artifactId>
         </dependency>
     </dependencies>
 

--- a/mvn-install
+++ b/mvn-install
@@ -15,7 +15,7 @@ fi
 
 echo "Building project"
 
-mvn clean package docker:build
+mvn -P conductr clean package docker:build
 
 echo "Restarting ConductR to ensure a clean state..."
 sandbox restart

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,25 @@
 
     <build>
         <plugins>
+          <plugin>
+          		<groupId>org.apache.maven.plugins</groupId>
+          		<artifactId>maven-antrun-plugin</artifactId>
+          		<version>1.7</version>
+          		<executions>
+          		    <execution>
+          		        <phase>validate</phase>
+          		          <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                          <target>
+                            <echo>Build target: ${buildTarget}</echo>
+                            <echo>Service Locator provided by: ${serviceLocator.provider.groupName}.${serviceLocator.provider.artifactName}:${serviceLocator.provider.artifactVersion}</echo>
+                          </target>
+                        </configuration>
+          		    </execution>
+          		</executions>
+          	</plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.6</version>
@@ -100,11 +119,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>com.typesafe.conductr</groupId>
-                <artifactId>${conductr.lib.name}</artifactId>
-                <version>1.9.1</version>
-            </dependency>
             <!-- front-end webjars -->
             <dependency>
                 <groupId>org.webjars</groupId>
@@ -131,13 +145,60 @@
                 <artifactId>jquery</artifactId>
                 <version>2.2.4</version>
             </dependency>
+            <!-- Service Locator Provider -->
+            <dependency>
+                <groupId>${serviceLocator.provider.groupName}</groupId>
+                <artifactId>${serviceLocator.provider.artifactName}</artifactId>
+                <version>${serviceLocator.provider.artifactVersion}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <lagom.version>1.3.4</lagom.version>
+        <!--
         <conductr.lib.name>lagom1-java-conductr-bundle-lib_2.11</conductr.lib.name>
+        -->
     </properties>
+
+
+    <repositories>
+      <repository>
+        <id>akka-dns</id>
+        <name>akka-dns</name>
+        <url>https://dl.bintray.com/hajile/maven</url>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </repository>
+    </repositories>
+
+    <profiles>
+      <profile>
+        <id>conductr</id>
+        <properties>
+          <buildTarget>conductr</buildTarget>
+          <serviceLocator.provider.groupName>com.typesafe.conductr</serviceLocator.provider.groupName>
+          <serviceLocator.provider.artifactName>lagom1-java-conductr-bundle-lib_2.11</serviceLocator.provider.artifactName>
+          <serviceLocator.provider.artifactVersion>1.9.1</serviceLocator.provider.artifactVersion>
+        </properties>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+      </profile>
+
+      <profile>
+        <id>kubernetes</id>
+        <properties>
+          <buildTarget>kubernetes</buildTarget>
+          <serviceLocator.provider.groupName>com.lightbend</serviceLocator.provider.groupName>
+          <serviceLocator.provider.artifactName>lagom-service-locator-dns_2.11</serviceLocator.provider.artifactName>
+          <serviceLocator.provider.artifactVersion>1.0.2</serviceLocator.provider.artifactVersion>
+        </properties>
+        <activation>
+          <activeByDefault>true</activeByDefault>
+        </activation>
+      </profile>
+    </profiles>
 </project>

--- a/project/BuildTarget.scala
+++ b/project/BuildTarget.scala
@@ -1,0 +1,25 @@
+import sbt._
+
+object BuildTarget {
+  private sealed trait DeploymentRuntime
+  private case object ConductR extends DeploymentRuntime
+  private case object Kubernetes extends DeploymentRuntime
+
+  private val deploymentRuntime: DeploymentRuntime = sys.props.get("buildTarget") match {
+    case Some(v) if v.toLowerCase == "conductr" =>
+      ConductR
+
+    case Some(v) if v.toLowerCase == "kubernetes" =>
+      Kubernetes
+
+    case Some(v) =>
+      sys.error(s"The build target $v is not supported. Only supports 'conductr' or 'kubernetes'")
+
+    case None =>
+      ConductR
+  }
+
+  val additionalLibraryDependencies: Seq[ModuleID] =
+    if (deploymentRuntime == Kubernetes) Seq(Library.serviceLocatorDns) else Seq.empty
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,9 @@
+import sbt._
+
+object Version {
+  val serviceLocatorDns = "1.0.2"
+}
+
+object Library {
+  val serviceLocatorDns = "com.lightbend" %% "lagom-service-locator-dns" % Version.serviceLocatorDns
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,24 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
-addSbtPlugin("com.github.stonexx.sbt" % "sbt-webpack" % "1.2.0")
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.3.0")
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
+import sbt._
+import sbt.Defaults.sbtPluginExtra
+
+libraryDependencies ++= {
+  val sbtV = (sbtBinaryVersion in update).value
+  val scalaV = (scalaBinaryVersion in update).value
+
+  val defaultPlugins: Seq[ModuleID] =
+    Seq(
+      sbtPluginExtra("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6", sbtV, scalaV),
+      sbtPluginExtra("com.github.stonexx.sbt" % "sbt-webpack" % "1.2.0", sbtV, scalaV),
+      sbtPluginExtra("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0", sbtV, scalaV)
+    )
+
+  val sbtConductRPlugin = sbtPluginExtra("com.lightbend.conductr" % "sbt-conductr" % "2.3.0", sbtV, scalaV)
+  val additionalPlugins: Seq[ModuleID] =
+    sys.props.get("buildTarget") match {
+      case Some(v) if v.toLowerCase == "conductr" => Seq(sbtConductRPlugin)
+      case None => Seq(sbtConductRPlugin)
+      case _ => Seq.empty
+    }
+
+  defaultPlugins ++ additionalPlugins
+}


### PR DESCRIPTION
This PR enables deployment of Lagom Chirper to Kubernetes.

**Kubernetes Deployment Artefacts**

This PR adds Kubernetes resource files which can be used to deploy the published Chirper docker images into Kubernetes.

An install script is added to allow end-user to execute all required deployment steps from this single script.

The resource files and the install scripts are located in `deploy/kubernetes/resources/` and `deploy/kubernetes/scripts/` respectively.

**Build Changes**

The Lagom Chirper packaging for both Maven and SBT has been modified to support deployment to Kubernetes.

**Maven Build Changes**

Maven now has 2 build profiles for Kubernetes and ConductR respectively which can be triggered with `-P kubernetes` and `-P conductr` respectively.

The Kubernetes profile will include service locator provided by [service-locator-dns](https://github.com/typesafehub/service-locator-dns), while ConductR profile will include service locator provided by [conductr-bundle-lib](https://github.com/typesafehub/conductr-lib)

The Kubernetes profile is active by default, and as such deployment to ConductR now required `-Pconductr` to be specified.

The ConductR deployment Maven deployment script `mvn-install` has been updated accordingly.


**SBT Build Changes**

SBT now accepts `-DbuildTarget=kubernetes` and `-DbuildTarget=conductr` to target Kubernetes and ConductR respectively.

If `-DbuildTarget` is not specified, the ConductR is targeted by default as we'd like to maintain the same experience of using `sbt install`.

The ConductR build target will enable `sbt-conductr` plugin, which will in turn include service locator provided by [conductr-bundle-lib](https://github.com/typesafehub/conductr-lib).

The `sbt-conductr` plugin will be disabled during Kubernetes build target. In the Kubernetes build target, the service locator provided by [service-locator-dns](https://github.com/typesafehub/service-locator-dns).



