### PR TITLE
Fix syntax for incrementing to be more portable

### DIFF
--- a/activity-stream-impl/pom.xml
+++ b/activity-stream-impl/pom.xml
@@ -103,7 +103,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-activityservice-v1}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-activityservice-v1}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val friendImpl = project("friend-impl")
     version := "1.0-SNAPSHOT",
     dockerRepository := Some("chirper"),
     dockerUpdateLatest := true,
-    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-friendservice-v1}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
+    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-friendservice-v1}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
     dockerCommands :=
       dockerCommands.value.flatMap {
         case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))
@@ -54,7 +54,7 @@ lazy val chirpImpl = project("chirp-impl")
     version := "1.0-SNAPSHOT",
     dockerRepository := Some("chirper"),
     dockerUpdateLatest := true,
-    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-chirpservice-v1}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
+    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-chirpservice-v1}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
     dockerCommands :=
       dockerCommands.value.flatMap {
         case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))
@@ -83,7 +83,7 @@ lazy val activityStreamImpl = project("activity-stream-impl")
     version := "1.0-SNAPSHOT",
     dockerRepository := Some("chirper"),
     dockerUpdateLatest := true,
-    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-activityservice-v1}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
+    dockerEntrypoint ++= """-Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-activityservice-v1}" -Dhttp.address="$ACTIVITYSERVICE_BIND_IP" -Dhttp.port="$ACTIVITYSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on""".split(" ").toSeq,
     dockerCommands :=
       dockerCommands.value.flatMap {
         case ExecCmd("ENTRYPOINT", args @ _*) => Seq(Cmd("ENTRYPOINT", args.mkString(" ")))

--- a/chirp-impl/pom.xml
+++ b/chirp-impl/pom.xml
@@ -93,7 +93,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-chirpservice-v1}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-chirpservice-v1}" -Dhttp.address="$CHIRPSERVICE_BIND_IP" -Dhttp.port="$CHIRPSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>

--- a/friend-impl/pom.xml
+++ b/friend-impl/pom.xml
@@ -89,7 +89,7 @@
                         <image>
                             <build>
                                 <entryPoint>
-                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-friendservice-v1}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$[$I+1]; done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
+                                    java -cp '/maven/*' -Dplay.crypto.secret="${APPLICATION_SECRET:-none}" -Dplay.akka.actor-system="${AKKA_ACTOR_SYSTEM_NAME:-friendservice-v1}" -Dhttp.address="$FRIENDSERVICE_BIND_IP" -Dhttp.port="$FRIENDSERVICE_BIND_PORT" -Dakka.actor.provider=cluster -Dakka.remote.netty.tcp.hostname="$(eval "echo $AKKA_REMOTING_BIND_HOST")" -Dakka.remote.netty.tcp.port="$AKKA_REMOTING_BIND_PORT" $(IFS=','; I=0; for NODE in $AKKA_SEED_NODES; do echo "-Dakka.cluster.seed-nodes.$I=akka.tcp://$AKKA_ACTOR_SYSTEM_NAME@$NODE"; I=$(expr $I + 1); done) -Dakka.io.dns.resolver=async-dns -Dakka.io.dns.async-dns.resolve-srv=true -Dakka.io.dns.async-dns.resolv-conf=on play.core.server.ProdServerStart
                                 </entryPoint>
                             </build>
                         </image>


### PR DESCRIPTION
This PR fixes replaces all occurrences of `I=$[$I+1]` with the more portable `I=$(expr $I + 1)`.

Net result: Akka seed nodes are declared correctly. This was verified by setting `-Dakka.log-config-on-start=on` and checking the value of the seed nodes properties.

Prior to this fix:

```
            "seed-nodes" : {
                # system properties
                "0" : "akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551",
                # system properties
                "$[$[0+1]+1]" : "akka.tcp://friendservice-v1@friendservice-2.friendservice.default.svc.cluster.local:2551",
                # system properties
                "$[0+1]" : "akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551"
            }
```

After this fix:

```
            "seed-nodes" : {
                # system properties
                "0" : "akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551",
                # system properties
                "1" : "akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551",
                # system properties
                "2" : "akka.tcp://friendservice-v1@friendservice-2.friendservice.default.svc.cluster.local:2551"
            }
```

Log showing correct rescheduling of `friendservice-0`:

```
2017-09-28T17:14:27.138Z [info] org.hibernate.validator.internal.util.Version [] - HV000001: Hibernate Validator 5.2.4.Final
2017-09-28T17:14:27.303Z [info] play.api.Play [] - Application started (Prod)
2017-09-28T17:14:27.537Z [info] play.core.server.NettyServer [] - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
2017-09-28T17:14:36.762Z [info] akka.cluster.Cluster(akka://friendservice-v1) [sourceThread=friendservice-v1-akka.actor.default-dispatcher-20, akkaTimestamp=17:14:36.762UTC, akkaSource=akka.cluster.Cluster(akka://friendservice-v1), sourceActorSystem=friendservice-v1] - Cluster Node [akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551] - Welcome from [akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551]
2017-09-28T17:14:36.858Z [info] akka.cluster.singleton.ClusterSingletonProxy [sourceThread=friendservice-v1-akka.actor.default-dispatcher-5, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/user/readSideGlobalPrepare-FriendEventProcessor-singletonProxy, sourceActorSystem=friendservice-v1, akkaTimestamp=17:14:36.857UTC] - Singleton identified at [akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551/user/readSideGlobalPrepare-FriendEventProcessor-singleton/singleton]
2017-09-28T17:14:36.863Z [info] akka.cluster.singleton.ClusterSingletonProxy [sourceThread=friendservice-v1-akka.actor.default-dispatcher-3, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/user/cassandraOffsetStorePrepare-singletonProxy, sourceActorSystem=friendservice-v1, akkaTimestamp=17:14:36.862UTC] - Singleton identified at [akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551/user/cassandraOffsetStorePrepare-singleton/singleton]
2017-09-28T17:14:37.059Z [warn] akka.cluster.sharding.ShardRegion [sourceThread=friendservice-v1-akka.actor.default-dispatcher-15, akkaTimestamp=17:14:37.057UTC, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/system/sharding/FriendEventProcessor, sourceActorSystem=friendservice-v1] - Trying to register to coordinator at [Some(ActorSelection[Anchor(akka.tcp://friendservice-v1@friendservice-1.friendservice.default.svc.cluster.local:2551/), Path(/system/sharding/FriendEventProcessorCoordinator/singleton/coordinator)])], but no acknowledgement. Total [1] buffered messages.
2017-09-28T17:14:38.304Z [info] akka.cluster.singleton.ClusterSingletonManager [sourceThread=friendservice-v1-akka.actor.default-dispatcher-4, akkaTimestamp=17:14:38.304UTC, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/user/cassandraOffsetStorePrepare-singleton, sourceActorSystem=friendservice-v1] - ClusterSingletonManager state change [Start -> Younger]
2017-09-28T17:14:38.306Z [info] akka.cluster.singleton.ClusterSingletonManager [sourceThread=friendservice-v1-akka.actor.default-dispatcher-2, akkaTimestamp=17:14:38.306UTC, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/user/readSideGlobalPrepare-FriendEventProcessor-singleton, sourceActorSystem=friendservice-v1] - ClusterSingletonManager state change [Start -> Younger]
2017-09-28T17:14:38.308Z [info] akka.cluster.singleton.ClusterSingletonManager [sourceThread=friendservice-v1-akka.actor.default-dispatcher-3, akkaTimestamp=17:14:38.308UTC, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/system/sharding/FriendEntityCoordinator, sourceActorSystem=friendservice-v1] - ClusterSingletonManager state change [Start -> Younger]
2017-09-28T17:14:38.316Z [info] akka.cluster.singleton.ClusterSingletonManager [sourceThread=friendservice-v1-akka.actor.default-dispatcher-3, akkaTimestamp=17:14:38.316UTC, akkaSource=akka.tcp://friendservice-v1@friendservice-0.friendservice.default.svc.cluster.local:2551/system/sharding/FriendEventProcessorCoordinator, sourceActorSystem=friendservice-v1] - ClusterSingletonManager state change [Start -> Younger]
```