### PR TITLE
Limit resource usage on Kubernetes

### DIFF
--- a/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
@@ -19,6 +19,11 @@
             "name": "activityservice",
             "image": "chirper/activity-stream-impl",
             "imagePullPolicy": "Never",
+            "resources": {
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
             "ports": [
               {
                 "containerPort": 9000,

--- a/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
@@ -19,6 +19,11 @@
             "name": "chirpservice",
             "image": "chirper/chirp-impl",
             "imagePullPolicy": "Never",
+            "resources": {
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
             "ports": [
               {
                 "containerPort": 9000,

--- a/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
@@ -19,6 +19,11 @@
             "name": "friendservice",
             "image": "chirper/friend-impl",
             "imagePullPolicy": "Never",
+            "resources": {
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
             "ports": [
               {
                 "containerPort": 9000,

--- a/deploy/kubernetes/resources/chirper/front-end-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/front-end-statefulset.json
@@ -19,6 +19,11 @@
             "name": "web",
             "image": "chirper/front-end",
             "imagePullPolicy": "Never",
+            "resources": {
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
             "ports": [
               { "containerPort": 9000 }
             ],


### PR DESCRIPTION
Updates K8s resources to match those declared for DC/OS. Works nicely with #96 