### PR TITLE
use kubernetes resource folder instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
                   <directory>src/main/resources</directory>
               </resource>
               <resource>
-                  <directory>src/main/marathon-resources</directory>
+                  <directory>src/main/kubernetes-resources</directory>
               </resource>
           </resources>
         </build>


### PR DESCRIPTION
Fixes #100 

For some reason, Kubernetes profile in maven is reading marathon-resources folder instead of kubernetes-resources. Probably a wrong commit.
