### PR TITLE
Remove invalid key names from k8s/marathon resources

### DIFF
--- a/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/activity-stream-impl-statefulset.json
@@ -32,14 +32,12 @@
             ],
             "env": [
               {
-                "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-                "_NOTE1": "!!! Be sure to change APPLICATION_SECRET's value (below) before deploying !!!",
-
                 "name": "APPLICATION_SECRET",
-                "value": "changeme!",
-
-                "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                "value": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
               },
+
+
+
               {
                 "name": "ACTIVITYSERVICE_BIND_PORT",
                 "value": "9000"

--- a/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/chirp-impl-statefulset.json
@@ -36,14 +36,12 @@
             ],
             "env": [
               {
-                "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-                "_NOTE1": "!!! Be sure to change APPLICATION_SECRET's value (below) before deploying !!!",
-
                 "name": "APPLICATION_SECRET",
-                "value": "changeme!",
-
-                "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                "value": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
               },
+
+
+
               {
                 "name": "CASSANDRA_SERVICE_NAME",
                 "value": "_native._tcp.cassandra.default.svc.cluster.local"

--- a/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/friend-impl-statefulset.json
@@ -36,14 +36,12 @@
             ],
             "env": [
               {
-                "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-                "_NOTE1": "!!! Be sure to change APPLICATION_SECRET's value (below) before deploying !!!",
-
                 "name": "APPLICATION_SECRET",
-                "value": "changeme!",
-
-                "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                "value": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
               },
+
+
+              
               {
                 "name": "CASSANDRA_SERVICE_NAME",
                 "value": "_native._tcp.cassandra.default.svc.cluster.local"

--- a/deploy/kubernetes/resources/chirper/front-end-statefulset.json
+++ b/deploy/kubernetes/resources/chirper/front-end-statefulset.json
@@ -29,13 +29,8 @@
             ],
             "env": [
               {
-                "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-                "_NOTE1": "!!! Be sure to change APPLICATION_SECRET's value (below) before deploying !!!",
-
                 "name": "APPLICATION_SECRET",
-                "value": "changeme!",
-
-                "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                "value": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
               },
               {
                 "name": "WEB_BIND_PORT",

--- a/deploy/marathon/resources/chirper.json
+++ b/deploy/marathon/resources/chirper.json
@@ -19,13 +19,7 @@
         "ACTIVITYSERVICE_BIND_IP": "0.0.0.0",
         "ACTIVITYSERVICE_BIND_PORT": "$PORT0",
 
-
-        "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-        "_NOTE1": "!!! Be sure to change APPLICATION_SECRET (below) before deploying !!!",
-        "APPLICATION_SECRET": "changeme!",
-        "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
-
+        "APPLICATION_SECRET": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
       },
       "labels": {
         "HAPROXY_GROUP": "external",
@@ -67,12 +61,7 @@
         "AKKA_REMOTING_BIND_PORT": "$PORT1",
 
 
-        "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-        "_NOTE1": "!!! Be sure to change APPLICATION_SECRET (below) before deploying !!!",
-        "APPLICATION_SECRET": "changeme!",
-        "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
-
+        "APPLICATION_SECRET": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
       },
       "labels": {
         "HAPROXY_GROUP": "external",
@@ -114,11 +103,7 @@
         "AKKA_REMOTING_BIND_PORT": "$PORT1",
 
 
-        "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-        "_NOTE1": "!!! Be sure to change APPLICATION_SECRET (below) before deploying !!!",
-        "APPLICATION_SECRET": "changeme!",
-        "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
+        "APPLICATION_SECRET": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
       },
       "labels": {
         "HAPROXY_GROUP": "external",
@@ -153,11 +138,7 @@
         "WEB_BIND_PORT": "$PORT0",
 
 
-        "_NOTE0": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-        "_NOTE1": "!!! Be sure to change APPLICATION_SECRET (below) before deploying !!!",
-        "APPLICATION_SECRET": "changeme!",
-        "_NOTE2": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
+        "APPLICATION_SECRET": "ATTENTION_BE_SURE_TO_CHANGE_ME!!!!"
       },
       "labels": {
         "HAPROXY_GROUP": "external",


### PR DESCRIPTION
This removes the invalid keys (`_NOTEx`) used to grab the attention, which was causing `kubectl` validation to fail.

Fixes #103 