### PR TITLE
[WIP] Remove cluster from activity stream (unused)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,6 @@ lazy val activityStreamImpl = project("activity-stream-impl")
     resolvers += bintrayRepo("hajile", "maven"),
     resolvers += bintrayRepo("hseeberger", "maven"),
     libraryDependencies ++= Seq(
-      lagomJavadslCluster,
       lagomJavadslTestKit
     )
   )


### PR DESCRIPTION
This removes `lagomJavadslCluster` from `activity-stream-impl` as it is unused -- only `chirp-impl` and `friend-impl` use clustering.