### PR TITLE
Setup CSP promiscuously on Play's filter

### DIFF
--- a/front-end/src/main/resources/application.conf
+++ b/front-end/src/main/resources/application.conf
@@ -2,3 +2,5 @@ play.crypto.secret = "changeme"
 play.crypto.secret = ${?APPLICATION_SECRET}
 
 include "platform.conf"
+
+play.filters.headers.contentSecurityPolicy = "connect-src *; style-src *;"


### PR DESCRIPTION
Fixes #111 by allowing all `content-src` and `style-src`.

Since this is a demo application that may run on very diverse environments (not just localhost:9000, but also k8s, etc...) I think setting the restrictions for `connect-src` and `styles-src` is good enough. Note that `connect-src` won't work with `'self'` because both `http://localhost:9000` and `ws://localhost:9000` are required (I'm not sure if there's a way to wilcard the scheme of the URI as in `*://localhost:9000`).