### PR TITLE
Adds ordering and active wait

### DIFF
--- a/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
+++ b/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
@@ -30,17 +30,25 @@ public class ChirpServiceTest {
 
     private static TestServer server;
 
+    // Creating a new persistent entity is slow in some runtime environment (e.g. free tier Travis) causing the
+    // tests to fail on timeout. First time we invoke a call that requires a persistent entity we will
+    // wait a bit longer.
+    private static int firstRequestOnEntityTimeout;
+    private static final int secondRequestOnEntityTimeout = 1;
+
     @BeforeClass
     public static void setUp() throws InterruptedException, ExecutionException, TimeoutException {
         server = startServer(defaultSetup().withCassandra(true));
 
-        // Let's not rush into things...
-        // this is a canary wait to ensure the server is up and running so tests can start. If
+        // This is a canary wait to ensure the server is up and running so tests can start. If
         // this fails it's not a test failure, it's that the machine running this is slow.
         ChirpService chirpService = server.client(ChirpService.class);
         LiveChirpsRequest request = new LiveChirpsRequest(TreePVector.<String>empty().plus("usr1").plus("usr2"));
         chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(10, SECONDS);
 
+        // First time a given PE is requested it may take longer to respond. Let's run the tests with
+        // timeouts equivalent to production settings _plus_ one second.
+        firstRequestOnEntityTimeout = 1 + (int) server.app().config().getDuration("lagom.persistence.ask-timeout", SECONDS);
     }
 
     @AfterClass
@@ -61,17 +69,17 @@ public class ChirpServiceTest {
         probe2.request(10);
 
         Chirp chirp1 = new Chirp("usr1", "hello 1");
-        chirpService.addChirp("usr1").invoke(chirp1).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr1").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
         probe1.expectNext(chirp1);
         probe2.expectNext(chirp1);
 
         Chirp chirp2 = new Chirp("usr1", "hello 2");
-        chirpService.addChirp("usr1").invoke(chirp2).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr1").invoke(chirp2).toCompletableFuture().get(secondRequestOnEntityTimeout, SECONDS);
         probe1.expectNext(chirp2);
         probe2.expectNext(chirp2);
 
         Chirp chirp3 = new Chirp("usr2", "hello 3");
-        chirpService.addChirp("usr2").invoke(chirp3).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr2").invoke(chirp3).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
         probe1.expectNext(chirp3);
         probe2.expectNext(chirp3);
 
@@ -84,10 +92,10 @@ public class ChirpServiceTest {
         ChirpService chirpService = server.client(ChirpService.class);
 
         Chirp chirp1 = new Chirp("usr3", "hi 1");
-        chirpService.addChirp("usr3").invoke(chirp1).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr3").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
 
         Chirp chirp2 = new Chirp("usr4", "hi 2");
-        chirpService.addChirp("usr4").invoke(chirp2).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr4").invoke(chirp2).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
 
         LiveChirpsRequest request = new LiveChirpsRequest(TreePVector.<String>empty().plus("usr3").plus("usr4"));
 
@@ -110,10 +118,10 @@ public class ChirpServiceTest {
         ChirpService chirpService = server.client(ChirpService.class);
 
         Chirp chirp1 = new Chirp("usr5", "msg 1");
-        chirpService.addChirp("usr5").invoke(chirp1).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr5").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
 
         Chirp chirp2 = new Chirp("usr6", "msg 2");
-        chirpService.addChirp("usr6").invoke(chirp2).toCompletableFuture().get(3, SECONDS);
+        chirpService.addChirp("usr6").invoke(chirp2).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
 
         HistoricalChirpsRequest request = new HistoricalChirpsRequest(Instant.now().minusSeconds(20),
             TreePVector.<String>empty().plus("usr5").plus("usr6"));

--- a/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
+++ b/chirp-impl/src/test/java/sample/chirper/chirp/impl/ChirpServiceTest.java
@@ -33,8 +33,9 @@ public class ChirpServiceTest {
     // Creating a new persistent entity is slow in some runtime environment (e.g. free tier Travis) causing the
     // tests to fail on timeout. First time we invoke a call that requires a persistent entity we will
     // wait a bit longer.
-    private static int firstRequestOnEntityTimeout;
-    private static final int secondRequestOnEntityTimeout = 1;
+    private static int persistentEntityDefault;
+    private static final int probeRequestTimeout = 10;
+    private static final int serviceInvocationTimeout = 3;
 
     @BeforeClass
     public static void setUp() throws InterruptedException, ExecutionException, TimeoutException {
@@ -46,9 +47,8 @@ public class ChirpServiceTest {
         LiveChirpsRequest request = new LiveChirpsRequest(TreePVector.<String>empty().plus("usr1").plus("usr2"));
         chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(10, SECONDS);
 
-        // First time a given PE is requested it may take longer to respond. Let's run the tests with
-        // timeouts equivalent to production settings _plus_ one second.
-        firstRequestOnEntityTimeout = 1 + (int) server.app().config().getDuration("lagom.persistence.ask-timeout", SECONDS);
+        // Let's run the tests with timeouts equivalent to production settings _plus_ one second.
+        persistentEntityDefault = 1 + (int) server.app().config().getDuration("lagom.persistence.ask-timeout", SECONDS);
     }
 
     @AfterClass
@@ -61,25 +61,25 @@ public class ChirpServiceTest {
     public void shouldPublishChirpsToSubscribers() throws Exception {
         ChirpService chirpService = server.client(ChirpService.class);
         LiveChirpsRequest request = new LiveChirpsRequest(TreePVector.<String>empty().plus("usr1").plus("usr2"));
-        Source<Chirp, ?> chirps1 = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(1, SECONDS);
+        Source<Chirp, ?> chirps1 = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(serviceInvocationTimeout, SECONDS);
         Probe<Chirp> probe1 = chirps1.runWith(TestSink.probe(server.system()), server.materializer());
-        probe1.request(10);
-        Source<Chirp, ?> chirps2 = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(1, SECONDS);
+        probe1.request(probeRequestTimeout);
+        Source<Chirp, ?> chirps2 = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(serviceInvocationTimeout, SECONDS);
         Probe<Chirp> probe2 = chirps2.runWith(TestSink.probe(server.system()), server.materializer());
-        probe2.request(10);
+        probe2.request(probeRequestTimeout);
 
         Chirp chirp1 = new Chirp("usr1", "hello 1");
-        chirpService.addChirp("usr1").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp1);
         probe1.expectNext(chirp1);
         probe2.expectNext(chirp1);
 
         Chirp chirp2 = new Chirp("usr1", "hello 2");
-        chirpService.addChirp("usr1").invoke(chirp2).toCompletableFuture().get(secondRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp2);
         probe1.expectNext(chirp2);
         probe2.expectNext(chirp2);
 
         Chirp chirp3 = new Chirp("usr2", "hello 3");
-        chirpService.addChirp("usr2").invoke(chirp3).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp3);
         probe1.expectNext(chirp3);
         probe2.expectNext(chirp3);
 
@@ -92,21 +92,21 @@ public class ChirpServiceTest {
         ChirpService chirpService = server.client(ChirpService.class);
 
         Chirp chirp1 = new Chirp("usr3", "hi 1");
-        chirpService.addChirp("usr3").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp1);
 
         Chirp chirp2 = new Chirp("usr4", "hi 2");
-        chirpService.addChirp("usr4").invoke(chirp2).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp2);
 
         LiveChirpsRequest request = new LiveChirpsRequest(TreePVector.<String>empty().plus("usr3").plus("usr4"));
 
         eventually(FiniteDuration.create(10, SECONDS), () -> {
-            Source<Chirp, ?> chirps = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(3, SECONDS);
+            Source<Chirp, ?> chirps = chirpService.getLiveChirps().invoke(request).toCompletableFuture().get(serviceInvocationTimeout, SECONDS);
             Probe<Chirp> probe = chirps.runWith(TestSink.probe(server.system()), server.materializer());
-            probe.request(10);
+            probe.request(probeRequestTimeout);
             probe.expectNextUnordered(chirp1, chirp2);
 
             Chirp chirp3 = new Chirp("usr4", "hi 3");
-            chirpService.addChirp("usr4").invoke(chirp3).toCompletableFuture().get(3, SECONDS);
+            addChirp(chirpService, chirp3);
             probe.expectNext(chirp3);
 
             probe.cancel();
@@ -118,20 +118,24 @@ public class ChirpServiceTest {
         ChirpService chirpService = server.client(ChirpService.class);
 
         Chirp chirp1 = new Chirp("usr5", "msg 1");
-        chirpService.addChirp("usr5").invoke(chirp1).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp1);
 
         Chirp chirp2 = new Chirp("usr6", "msg 2");
-        chirpService.addChirp("usr6").invoke(chirp2).toCompletableFuture().get(firstRequestOnEntityTimeout, SECONDS);
+        addChirp(chirpService, chirp2);
 
         HistoricalChirpsRequest request = new HistoricalChirpsRequest(Instant.now().minusSeconds(20),
             TreePVector.<String>empty().plus("usr5").plus("usr6"));
 
         eventually(FiniteDuration.create(10, SECONDS), () -> {
-            Source<Chirp, ?> chirps = chirpService.getHistoricalChirps().invoke(request).toCompletableFuture().get(3, SECONDS);
+            Source<Chirp, ?> chirps = chirpService.getHistoricalChirps().invoke(request).toCompletableFuture().get(serviceInvocationTimeout, SECONDS);
             Probe<Chirp> probe = chirps.runWith(TestSink.probe(server.system()), server.materializer());
-            probe.request(10);
+            probe.request(probeRequestTimeout);
             probe.expectNextUnordered(chirp1, chirp2);
             probe.expectComplete();
         });
+    }
+
+    private void addChirp(ChirpService chirpService, Chirp chirp) throws InterruptedException, ExecutionException, TimeoutException {
+        chirpService.addChirp(chirp.userId).invoke(chirp).toCompletableFuture().get(persistentEntityDefault, SECONDS);
     }
 }


### PR DESCRIPTION
Introduces JUnit's `FixMethodOrder` to enforce a well known order (instead of letting an obscure, yet predictable, orderig take over).

Adds an active wait on the `setUp` method so that tests don't start until the server is known to be ready to reply. This acts as a canary timeout so that when that active wait times out we know the runtime is slow instead of having to look into whether the cause is a bad test or a bad environment.